### PR TITLE
6 0 4198 punchbox centos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ vagrant/Vagrantfile
 ansible/punchbox.*
 .idea
 .idea/**
+punch/build

--- a/README.md
+++ b/README.md
@@ -151,3 +151,7 @@ Refer to the [ansible](./ansible/README.md) guide.
 This repository is licensed under the ApacheV2 license, please feel free to contribute. 
 Only the punch itself is submitted to license, but is not necessary to use the vagrant or kube 
 parts.
+
+## Troubleshooting
+
+Refer to the [troubleshooting](./Troubleshooting.md) documentation if you encounter some problems:

--- a/README.md
+++ b/README.md
@@ -151,22 +151,3 @@ Refer to the [ansible](./ansible/README.md) guide.
 This repository is licensed under the ApacheV2 license, please feel free to contribute. 
 Only the punch itself is submitted to license, but is not necessary to use the vagrant or kube 
 parts.
-
-## Troubleshooting
-
-### Vagrant was unable to mount VirtualBox shared folders
-
-Appears when the following error occurs:
-
-```sh
-Error
-mount -t vboxsf -o uid=1000,gid=1000 home_vagrant_public_html_apps /home/vagrant/public_html/apps
-
-The error output from the command was:
-mount: unknown filesystem type ‘vboxsf'”
-```
-
-There are two ways you can fix this problem:
-
-* Install the vagrant vbguest plugin: vagrant plugin install vagrant-vbguest.
-* Make sure you’re running the latest box version. Update by running vagrant box update.

--- a/README.md
+++ b/README.md
@@ -152,4 +152,21 @@ This repository is licensed under the ApacheV2 license, please feel free to cont
 Only the punch itself is submitted to license, but is not necessary to use the vagrant or kube 
 parts.
 
+## Troubleshooting
 
+### Vagrant was unable to mount VirtualBox shared folders
+
+Appears when the following error occurs:
+
+```sh
+Error
+mount -t vboxsf -o uid=1000,gid=1000 home_vagrant_public_html_apps /home/vagrant/public_html/apps
+
+The error output from the command was:
+mount: unknown filesystem type ‘vboxsf'”
+```
+
+There are two ways you can fix this problem:
+
+* Install the vagrant vbguest plugin: vagrant plugin install vagrant-vbguest.
+* Make sure you’re running the latest box version. Update by running vagrant box update.

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -1,0 +1,37 @@
+# Troubleshooting
+
+## Vagrant was unable to mount VirtualBox shared folders
+
+Appears when the following error occurs:
+
+```sh
+Error
+mount -t vboxsf -o uid=1000,gid=1000 home_vagrant_public_html_apps /home/vagrant/public_html/apps
+
+The error output from the command was:
+mount: unknown filesystem type ‘vboxsf'”
+```
+
+There are two ways you can fix this problem:
+
+* Install the vagrant vbguest plugin: vagrant plugin install vagrant-vbguest.
+* Make sure you’re running the latest box version. Update by running vagrant box update.
+
+## Sync folder for configuration is empty after reboot
+
+Execute the followning command on the host :
+
+```sh
+vagrant reload
+```
+
+## Wrong interface returned by the generated interface
+
+Try to generate the configurations and the vagrant file again, without starting vagrant :
+
+```sh
+punchbox --config configurations/complete_punch_16G.json \
+        --generate-vagrantfile \
+        --punch-conf <path/to/existing/conf>
+        --deployer ~/pp-punch/pp-packaging/punchplatform-deployer/target/punchplatform-deployer-*.zip \
+```

--- a/bin/punchbox.py
+++ b/bin/punchbox.py
@@ -7,7 +7,7 @@ import zipfile
 import argparse
 import os, fnmatch
 from distutils.dir_util import copy_tree
-from shutil import copyfile
+from shutil import copyfile, copytree, ignore_patterns
 import uuid
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__)) # This is your Project Root
@@ -170,7 +170,10 @@ def findReplace(directory, find, replace, filePattern):
 
 ## IMPORT CHANNELS AND RESOURCES IN PP-CONF ##
 def import_resources(conf, user_config):
-  copy_tree(conf, conf_dir)
+  try:
+    copytree(conf, conf_dir, ignore=ignore_patterns('*punchplatform*'))
+  except FileExistsError:
+    pass
   copy_tree(validation_conf_dir, conf_dir)
   findReplace(conf_dir+"/tenants/validation", "{{spark_master}}", user_config["punch"]["spark"]["masters"][0], "*")
   logging.info(' punchplatform configuration successfully imported in %s', conf_dir)

--- a/bin/punchbox.py
+++ b/bin/punchbox.py
@@ -151,7 +151,7 @@ def create_resolver(user_config):
   file_loader = jinja2.FileSystemLoader(template_dir)
   env = jinja2.Environment(loader=file_loader)
   resolv_template = env.get_template(resolv_template_file)
-  resolv_render = resolv_template.render(punch=user_config["punch"], webhook=os.getenv('SLACK_WEBHOOK', ''), proxy=os.getenv('SLACK_PROXY', ''), hostname=os.uname()[1])
+  resolv_render = resolv_template.render(punch=user_config["punch"], webhook=os.getenv('SLACK_WEBHOOK', ''), proxy=os.getenv('SLACK_PROXY', ''), hostname=os.uname()[1], os=user_config["targets"]["meta"]["os"])
   resolv_file = open(resolv_target, "w+")
   resolv_file.write(resolv_render)
   resolv_file.close()

--- a/configurations/complete_punch_32G.json
+++ b/configurations/complete_punch_32G.json
@@ -29,7 +29,7 @@
       }
     },
     "meta": {
-      "os": "centos/7"
+      "os": "ubuntu/bionic64"
     }
   },
   "punch": {

--- a/configurations/complete_punch_32G.json
+++ b/configurations/complete_punch_32G.json
@@ -29,7 +29,7 @@
       }
     },
     "meta": {
-      "os": "ubuntu/bionic64"
+      "os": "centos/7"
     }
   },
   "punch": {

--- a/punch/validation/templates/resolv.hjson.j2
+++ b/punch/validation/templates/resolv.hjson.j2
@@ -166,7 +166,7 @@
          slack_proxy: "{{ proxy }}"
          slack_emoji_override: ":punchlogo2:"
          slack_msg_color: "danger"
-         slack_title: "6.0 validation from {{ hostname }}"
+         slack_title: "6.0 validation from {{ hostname }} on {{os}}"
       }
    }
      // Elastalert slack fail
@@ -183,7 +183,7 @@
         slack_proxy: "{{ proxy }}"
         slack_emoji_override: ":punchlogo2:"
         slack_msg_color: "good"
-        slack_title: "6.0 validation from {{ hostname }}"
+        slack_title: "6.0 validation from {{ hostname }} on {{os}}"
       }
    }
 }

--- a/vagrant/Vagrantfile.j2
+++ b/vagrant/Vagrantfile.j2
@@ -11,11 +11,17 @@ Vagrant.configure("2") do |config|
     vb.linked_clone = true
   end
 
+  {% if os is defined %}
+  {% set my_os = os %}
+  {% else %}
+  {% set my_os = targets.meta.os %}
+  {% endif %}
+
   {% for server in targets.info %}
 
    config.vm.define "{{ server }}" do |server|
-      
-      server.vm.box = "{{ targets.meta.os }}"
+
+      server.vm.box = "{{ my_os }}"
       server.vm.box_check_update = false
       config.disksize.size = '{{ targets.info[server].disksize }}'
 
@@ -33,16 +39,16 @@ Vagrant.configure("2") do |config|
         echo 'export LC_ALL=C' >> ~/.bashrc
         echo '#{PUBLIC_KEY}' >> /home/vagrant/.ssh/authorized_keys
       EOF
-      {% if targets.meta.os == 'ubuntu/bionic64' %}
+      {% if os == 'ubuntu/bionic64' %}
       server.vm.provision "shell", inline: "sudo ln -s /usr/bin/python3 /usr/bin/python"
       server.vm.provision "shell", inline: "sudo apt-get install -y python3-distutils"
       {% endif %}
 
-      {% if targets.meta.os == 'centos/7' %}
+      {% if os == 'centos/7' %}
       server.vm.provision "shell", inline: "sudo yum install -y python3-pip python3-venv"
       {% endif %}
 
-      {% if targets.meta.os != 'centos/7' %}
+      {% if os != 'centos/7' %}
       server.vm.provision "shell", inline: "sed -i '5,10d' /home/vagrant/.bashrc"
       {% endif %}
       server.vm.provision "shell", inline: "sed -i '/{{ server }}/d' /etc/hosts"

--- a/vagrant/Vagrantfile.j2
+++ b/vagrant/Vagrantfile.j2
@@ -42,7 +42,9 @@ Vagrant.configure("2") do |config|
       server.vm.provision "shell", inline: "sudo yum install -y python3-pip python3-venv"
       {% endif %}
 
+      {% if targets.meta.os != 'centos/7' %}
       server.vm.provision "shell", inline: "sed -i '5,10d' /home/vagrant/.bashrc"
+      {% endif %}
       server.vm.provision "shell", inline: "sed -i '/{{ server }}/d' /etc/hosts"
       server.vm.provision "shell", inline: "sudo timedatectl set-timezone Europe/Paris"
       server.vm.provision :shell, :inline => "sudo rm /etc/localtime && sudo ln -s /usr/share/zoneinfo/Europe/Paris /etc/localtime", run: "always"

--- a/vagrant/Vagrantfile.j2
+++ b/vagrant/Vagrantfile.j2
@@ -39,7 +39,7 @@ Vagrant.configure("2") do |config|
       {% endif %}
 
       {% if targets.meta.os == 'centos/7' %}
-      server.vm.provision "shell", inline: "sudo apt install -y python3-pip python3-venv"
+      server.vm.provision "shell", inline: "sudo yum install -y python3-pip python3-venv"
       {% endif %}
 
       server.vm.provision "shell", inline: "sed -i '5,10d' /home/vagrant/.bashrc"


### PR DESCRIPTION
# Changes

## fixes

* fix vagrant file generation for centos
* fix bashrc fields injection for centos
* fix punchbox copying unwanted punchplatform.properties from external source
* fix incorrect configuration resources importation

## improvements

* Add troubleshooting documentation document
* Add OS information in `check_platform` output

## features

* Add `--os` option to override OS inside the generated vagrant file
* Add `--interface` option to override interface usage inside the generated configuration

# Related issues

* pp-6 : Centos support for vagrant file generation and Punch deployment
* pp-7 : New --os and --interface command line options 

# Test

First of all, compile a fresh punchplatform (version 6.0)

Then in punchbox :

```sh   
# clean previous installation
make clean
make install
# generate vagrant file and configuration model
bin/punchbox --config configurations/complete_punch_32G.json --punch-conf <path/to/external/conf_dir> --deployer <path/to/deployer_zip> --os centos/7 --interface eth1 --generate-vagrantfile
# mount VMs with vagrant
cd vagrant
vagrant up
# generate configuration andcopy it inside the shared folder 
cd ..
punchplatform-deployer.sh --generate-platform-config --templates-dir punch/platform_template/ --model punch/build/model.json
cp $PUNCHPLATFORM_CONF_DIR/punchplatform.properties punch/build/pp-conf
# install punchplatform
punchplatform-deployer.sh deploy -u vagrant
# validate the platform
ssh vagrant@server1
pp-conf/check_platform.sh
```

# Validation

1. Merge the current branch inside the stable one
2. Test the changes
3. Verify the documentation actually relates about the current changes