### PR TITLE
pp-14 add install dir and data dir user configurations

### DIFF
--- a/configurations/README.md
+++ b/configurations/README.md
@@ -17,6 +17,8 @@ This file is composed as follow :
           - `os`: os for all boxes
 
   - `punch`: list of punch component
+      - `installation_directory` : path where the punch components binaries will be installed
+      - `data_storage_directory` : path where the punch components data will be stored
       - `elasticsearch`:
           - `servers`: list of elasticsearch hosts
           - `cluster_production_transport_address`: elasticsearch transport address

--- a/configurations/complete_punch_16G.json
+++ b/configurations/complete_punch_16G.json
@@ -23,6 +23,8 @@
     }
   },
   "punch": {
+    "installation_directory": "/data/opt",
+    "data_storage_directory": "/data",
     "elasticsearch": {
       "servers": [
         "server3"

--- a/configurations/complete_punch_32G.json
+++ b/configurations/complete_punch_32G.json
@@ -33,6 +33,8 @@
     }
   },
   "punch": {
+    "installation_directory": "/data/opt",
+    "data_storage_directory": "/data",
     "elasticsearch": {
       "servers": [
         "server2"

--- a/punch/platform_template/punchplatform-deployment.settings.j2
+++ b/punch/platform_template/punchplatform-deployment.settings.j2
@@ -1,6 +1,6 @@
 {
-    "setups_root": "/data/opt",
-    "remote_data_root_directory": "/data",
+    "setups_root": "{{ installation_directory }}",
+    "remote_data_root_directory": "{{data_storage_directory}}",
     "remote_logs_root_directory": "/var/log/punchplatform",
     "punchplatform_daemons_user": "{{ operator.username }}",
     "punchplatform_group": "{{ operator.username }}",

--- a/punch/platform_template/punchplatform.properties.j2
+++ b/punch/platform_template/punchplatform.properties.j2
@@ -20,7 +20,7 @@
         "punchplatform_root_node": "/punchplatform-primary"
       }
     },
-    "install_dir": "/data/opt/{{ version.zookeeper }}"
+    "install_dir": "{{ installation_directory }}/{{ version.zookeeper }}"
   },
   {% endif %}
 
@@ -203,7 +203,7 @@
         },
         "resources": {
           "resources_dir": "/home/{{ operator.username }}/pp-conf/resources",
-          "doc_dir": "/data/opt/punchplatform-docuementation-{{version.gateway}}/doc/html",
+          "doc_dir": "{{ installation_directory }}/punchplatform-docuementation-{{version.gateway}}/doc/html",
           "tmp_dir": "/tmp",
           "archives_dir": "/tmp"
         },
@@ -248,7 +248,7 @@
         "supervisor_cpu" : 2
       }
     },
-    "install_dir": "/data/opt/{{ version.storm }}"
+    "install_dir": "{{ installation_directory }}/{{ version.storm }}"
   },
   {% endif %} 
 
@@ -267,7 +267,7 @@
         "kafka_brokers_jvm_xmx": "{{ kafka.jvm_xmx }}"
       }
     },
-    "install_dir" : "/data/opt/{{ version.kafka }}"
+    "install_dir" : "{{ installation_directory }}/{{ version.kafka }}"
   },
   {% endif %}
 
@@ -292,7 +292,7 @@
         "plugins": [ "logstash", "spark", "storm" ]
       }
     },
-    "install_dir": "/data/opt/{{ version.shiva }}"
+    "install_dir": "{{ installation_directory }}/{{ version.shiva }}"
   },
   {% endif %}
 
@@ -327,13 +327,13 @@
         "slaves_memory" : "{{ spark.slaves_memory }}"
       }
     },
-    "install_dir": "/data/opt/{{ version.spark }}"
+    "install_dir": "{{ installation_directory }}/{{ version.spark }}"
   },
   {% endif %}
 
   {% if pyspark is defined %}
   "pyspark" : {
-    "install_dir": "/data/opt/punchplatform-pyspark-{{ version.pyspark }}",
+    "install_dir": "{{ installation_directory }}/punchplatform-pyspark-{{ version.pyspark }}",
         "servers": {{ pyspark.servers | tojson }}
   },
   {% endif %}
@@ -346,7 +346,7 @@
           "port": "9000"
         }
       },
-      "install_dir": "/data/opt/{{ version.minio }}"
+      "install_dir": "{{ installation_directory }}/{{ version.minio }}"
     },
   {% endif %}
   


### PR DESCRIPTION
# Pull Request

## Issue

* #14  Ajouter la possibilité de configurer l'emplacement d'installation de la punchplatform

## Testing

1. Compile a v6.0.x Punchplatform
2 . Edit the following configurations in `configurations/complete_punch_32G.json` for test purposes :

```json
{
    "punch": {
        "installation_directory": "/tmp/opt",
        "data_storage_directory": "/tmp
    }
}
``` 

3. Test with zookeeper deployment
```shell
cd $PUNCHBOX_DIR
make clean
make install
bin/punchbox --config configurations/complete_punch_32G.json \
    --punch-conf /home/user/punchplatform-standalone-6.0.1-SNAPSHOT-linux/conf/ \
    --deployer $PP_PUNCH_DIR/pp-packaging/punchplatform-deployer/target/punchplatform-deployer-6.0.1-SNAPSHOT.zip \
    --generate-vagrantfile
# mount VMs
cd vagrant
vagrant up
# generate configuration
cd ..
punchplatform-deployer.sh -gc --templates-dir punch/platform_template/ --model punch/build/model.json
# check configuration and deploy
punchplatform-deployer.sh -gi
punchplatform-deployer.sh deploy -kK --tags zookeeper
```

4. Check that zookeeper's binaries are located inside `/tmp/opt` and the zookeeper's data are located inside `/tmp`

## Author's checklist (You)

> Before submitting merge request:

- [x] Merge locally
- [x] Compile the same version of a Punchplatform 
- [x] Check that the documentation explains the changes
- [x] Explain how to test new features

## Reviewer's checklist (Reviewer)

- [ ] Technical review
- [ ] Check that the documentation explains these changes
- [ ] Review is done and tests passed.
- [ ] Notice the autor of finished review. **The autor must be the one to press merge**.