### PR TITLE
pp-15 fix optional gateway component, disable punch plugin for kibana

### DIFF
--- a/configurations/complete_punch_32G.json
+++ b/configurations/complete_punch_32G.json
@@ -51,12 +51,6 @@
       ],
       "childopts": "-server -Xmx128m -Xms128m"
     },
-    "gateway": {
-      "servers": [
-        "server1"
-      ],
-      "inet_address": "172.28.128.21"
-    },
     "storm": {
       "master": {
         "servers": [

--- a/punch/platform_template/punchplatform-deployment.settings.j2
+++ b/punch/platform_template/punchplatform-deployment.settings.j2
@@ -99,12 +99,14 @@
    {% if kibana is defined %}
    "kibana_version" : "{{ version.elastic }}",
    "kibana_plugins":{
+      {% if gateway is defined %}
    	  "punchplatform": {
         "version": "{{ version.punch }}"
       },
       "punchplatform-feedback": {
         "version": "{{ version.punch }}"
       }
+      {% endif %}
       {% if kibana.security is defined and kibana.security == True %}
       ,
       "opendistro_security": {

--- a/punch/platform_template/punchplatform.properties.j2
+++ b/punch/platform_template/punchplatform.properties.j2
@@ -120,12 +120,12 @@
       {% for server in gateway.servers  %}
       {% set server_ip = server_ip.append( "http://"+server+":"+port ) %}
       {% endfor %}
-      {% endif %} 
       "punchplatform": {
-      "rest_api": {
-        "hosts": {{ server_ip | tojson }}
+        "rest_api": {
+          "hosts": {{ server_ip | tojson }}
+        }
       }
-      }
+      {% endif %}
     }
   },
   {% endif %} 


### PR DESCRIPTION
# Pull Request

## Issue

* #15   Impossible de ne pas renseigner la section gateway

## Testing

1. Compile a v6.0.x Punchplatform
2 . Remove the `gateway` component section in `configurations/complete_punch_32G.json`
3. Check the generated configuration and ensure the gateway section and the plugin punch section in kibana are absent
4. Test with deployer

```shell
cd $PUNCHBOX_DIR
make clean
make install
bin/punchbox --config configurations/complete_punch_32G.json \
    --punch-conf /home/user/punchplatform-standalone-6.0.1-SNAPSHOT-linux/conf/ \
    --deployer $PP_PUNCH_DIR/pp-packaging/punchplatform-deployer/target/punchplatform-deployer-6.0.1-SNAPSHOT.zip \
    --generate-vagrantfile
# mount VMs
cd vagrant
vagrant up
# generate configuration
cd ..
punchplatform-deployer.sh -gc --templates-dir punch/platform_template/ --model punch/build/model.json
# check configuration and deploy
punchplatform-deployer.sh -gi
punchplatform-deployer.sh deploy -kK --tags zookeeper,operator,elasticsearch,kibana
```

5. Check that kibana is properly started

## Author's checklist (You)

> Before submitting merge request:

- [x] Merge locally
- [x] Compile the same version of a Punchplatform 
- [x] Check that the documentation explains the changes
- [x] Explain how to test new features

## Reviewer's checklist (Reviewer)

- [ ] Technical review
- [ ] Check that the documentation explains these changes
- [ ] Review is done and tests passed.
- [ ] Notice the autor of finished review. **The autor must be the one to press merge**.