### PR TITLE
803 - Add housekeeping and archiving to punchbox check

### DIFF
--- a/punch/configurations/validation/README.md
+++ b/punch/configurations/validation/README.md
@@ -64,6 +64,8 @@ Launch aggregation and apache channels from Punchplatform standalone and then us
   - Push some templates to Elasticsearch
   - Import Kibana dashboards 
   - Storm execution 
+  - Archiving : Checking some metadata is created by archiving
+  - Housekeeping : Checking metadata are removed by housekeeper
   - Plan and spark in foreground mode  
   - Log injectors 
   - Elasticsearch 

--- a/punch/configurations/validation/templates/check_platform.sh.j2
+++ b/punch/configurations/validation/templates/check_platform.sh.j2
@@ -16,6 +16,8 @@ echo -e "${BLUE}INFO:${RESET} Start channels from tenant mytenant"
 punchctl -t mytenant start --channel stormshield_networksecurity
 punchctl -t mytenant start --channel aggregation
 punchctl -t mytenant start --channel elastalert  
+punchctl -t mytenant start --channel apache_httpd
+punchctl -t mytenant start --channel admin
 
 echo -e "${BLUE}INFO:${RESET} Start channels from tenant mytenant"
 punchctl -t validation start 
@@ -25,6 +27,11 @@ echo -e "${BLUE}INFO:${RESET} Launch log injectors"
 
 {% for server in punch.shiva.servers %}
 nohup punchplatform-log-injector.sh -c $PUNCHPLATFORM_CONF_DIR/resources/injectors/mytenant/stormshield_networksecurity_injector.json -H {{ server }} &
+{% endfor %}
+
+// Send logs to all servers to match single unknown listening server. No logs actually injected to non-listening servers.
+{% for server in punch.storm.slaves %}
+nohup punchplatform-log-injector.sh -c $PUNCHPLATFORM_CONF_DIR/resources/injectors/mytenant/apache_httpd_injector.json -H {{ server }} &
 {% endfor %}
 
 echo -e "${BLUE}INFO:${RESET} Wait for 15 min, logs are being inserted in platform"

--- a/punch/configurations/validation/tenants/validation/channels/elastalert_validation/rules/check_archiving_failure.yaml
+++ b/punch/configurations/validation/tenants/validation/channels/elastalert_validation/rules/check_archiving_failure.yaml
@@ -1,0 +1,25 @@
+# Alert if no metadata is present after 10 min 
+
+name: Archiving fail
+
+type: flatline
+
+index: mytenant-archive-*
+
+threshold: 1
+timeframe: 
+  minutes: 10
+doc_type: _doc
+
+realert:
+ minutes: 15
+
+alert_text_type: alert_text_only
+alert_text: "\n Archiving ended with failure (No metadata found)"
+
+alert:
+- command
+
+command: 
+  - "/bin/echo"
+  - "alert: Archiving ended with failure (No metadata found)"

--- a/punch/configurations/validation/tenants/validation/channels/elastalert_validation/rules/check_archiving_success.yaml
+++ b/punch/configurations/validation/tenants/validation/channels/elastalert_validation/rules/check_archiving_success.yaml
@@ -1,0 +1,20 @@
+# Alert if some metadata is detected
+
+name: Archiving success
+
+type: any
+
+index: mytenant-archive-*
+
+realert:
+ minutes: 15
+
+alert_text_type: alert_text_only
+alert_text: "\n Archiving ended with success (At least one metadata found)"
+
+alert:
+- command
+
+command: 
+  - "/bin/echo"
+  - "alert: Archiving ended with success (At least one metadata found)"

--- a/punch/configurations/validation/tenants/validation/channels/elastalert_validation/rules/check_housekeeping_failure.yaml
+++ b/punch/configurations/validation/tenants/validation/channels/elastalert_validation/rules/check_housekeeping_failure.yaml
@@ -1,0 +1,33 @@
+# Alert if metadata older than 9 min is present
+#
+# 9 min explanation :
+#
+# The housekeeper retention time is 3 min. The housekeeper execution period is 5 min.
+# After execution, the older valid metadata is 3 min old.
+# Right before next execution, 5 min later, the older valid metadata is 5+3 min old. 
+# We add 1 min for safety : result is 9 min. 
+
+name: Archive Housekeeping fail
+
+type: any
+
+index: mytenant-archive-*
+
+filter:
+- query:
+    range:
+      timestamp:
+        lt: now-9m
+
+realert:
+ minutes: 15
+
+alert_text_type: alert_text_only
+alert_text: "\n Archive Housekeeping ended with failure (At least one metadata older than 9 minutes)"
+
+alert:
+- command
+
+command: 
+  - "/bin/echo"
+  - "alert: Housekeeping of archive ended with failure (At least one metadata older than 9 minutes)"

--- a/punch/configurations/validation/tenants/validation/channels/elastalert_validation/rules/check_housekeeping_success.yaml
+++ b/punch/configurations/validation/tenants/validation/channels/elastalert_validation/rules/check_housekeeping_success.yaml
@@ -1,0 +1,38 @@
+# Alert if no metadata older than 9 min is present
+#
+# 9 min explanation :
+#
+# The housekeeper retention time is 3 min. The housekeeper execution period is 5 min.
+# After execution, the older valid metadata is 3 min old.
+# Right before next execution, 5 min later, the older valid metadata is 5+3 min old. 
+# We add 1 min for safety : result is 9 min. 
+
+name: Archive Housekeeping success
+
+type: flatline
+
+index: mytenant-archive-*
+
+filter:
+- query:
+    range:
+      timestamp:
+        lt: now-9m
+
+threshold: 1
+timeframe:
+  minutes: 10
+doc_type: _doc
+
+realert:
+ minutes: 15
+
+alert_text_type: alert_text_only
+alert_text: "\n Archvie Housekeeping ended with success (No metadata older than 9 minutes)"
+
+alert:
+- command
+
+command: 
+  - "/bin/echo"
+  - "alert: Archive Housekeeping ended with success (No metadata older than 9 minutes)"

--- a/vagrant/Vagrantfile.j2
+++ b/vagrant/Vagrantfile.j2
@@ -32,6 +32,7 @@ Vagrant.configure("2") do |config|
       {%- if targets.info[server].synced_pp_conf_folder is defined %}
       server.vm.synced_folder '../punch/build/pp-conf', '/home/vagrant/pp-conf/'
       {%- endif %}
+      server.vm.synced_folder '/tmp/archive-log/storage', '/tmp/archive-logs/storage', create: true
       ## Configuration
       server.vm.hostname = "{{ server }}"
       server.vm.network "private_network", ip: "172.28.128.2{{ loop.index }}"


### PR DESCRIPTION
## Related Issue

https://gitlab.thalesdigital.io/punch/product/pp-punch/-/issues/803

## How was it tested ?

Deploy using complete_punch_32G configuration and run check-platform.sh.

Default : Elastalert send success for archiving and housekeeping
Without starting apache_httpd : Elastalert send success for housekeeping and failure for archiving
Without starting admin : Elastalert send success for archiving and failure for housekeeping

## Author's checklist (You)

> Before submitting merge request:

- [x] Resolve existing conflicts with a merge from the targeted branch into yours
- [x] Proceed to the tests
- [x] Check that the documentation explains these changes
- [x] Assign and inform a reviewer

> After success review :

- [ ] Push your branch

## Reviewer's checklist (Reviewer)

- [ ] Technical review with the author
- [ ] Proceed to the tests
- [ ] Check that the documentation explains these changes
- [ ] Review and tests are done
- [ ] Inform the autor that the rieview is validated. **The autor must be the one to merge its branch into the targeted one and push**
